### PR TITLE
change rules for querying helps

### DIFF
--- a/src/controllers/HelpController.js
+++ b/src/controllers/HelpController.js
@@ -34,15 +34,14 @@ class HelpController {
     }
 
     async getHelpList(req, res, next) {
-        const id = req.query.id || null;
+        const except = req.query["id.except"] ? true : false;
+        const helper = req.query["id.helper"] ? true : false;
+        const temp = except ? 'except' : helper ? 'helper' : null;
+        const id = temp ? req.query[`id.${temp}`] : req.query.id;
         const status = req.query.status || null;
         try {
             let result;
-            if (id && status) {
-                result = await this.HelpService.getHelpListByStatus(id, status);
-            } else {
-                result = await this.HelpService.getHelpList(id);
-            }
+            result = await this.HelpService.getHelpList(id, status, except, helper);
             res.status(200).json(result);
             next();
         } catch (err) {

--- a/src/repository/HelpRepository.js
+++ b/src/repository/HelpRepository.js
@@ -23,7 +23,6 @@ class HelpRepository extends BaseRepository {
         if (status) query.status = status;
         if (helper) query.helperId = helperId;
         else query.ownerId = ownerId
-        console.log(query)
         const result = await super.$list(query);
         return result;
     }

--- a/src/repository/HelpRepository.js
+++ b/src/repository/HelpRepository.js
@@ -16,15 +16,15 @@ class HelpRepository extends BaseRepository {
         return result;
     }
 
-    async list(id) {
-        const query = id ? { ownerId: { $ne: id } } : {};
-
+    async list(id, status, except, helper) {
+        const ownerId = except ? { $ne: id } : helper ? null : id;
+        const helperId = helper ? id : null;
+        const query = {}
+        if (status) query.status = status;
+        if (helper) query.helperId = helperId;
+        else query.ownerId = ownerId
+        console.log(query)
         const result = await super.$list(query);
-        return result;
-    }
-
-    async listByStatus(id, status) {
-        const result = await super.$list({ ownerId: id, status });
         return result;
     }
 }

--- a/src/services/HelpService.js
+++ b/src/services/HelpService.js
@@ -25,17 +25,8 @@ class HelpService {
         return Help;
     }
 
-    async getHelpList(id) {
-        const Helplist = await this.HelpRepository.list(id);
-        if (!Helplist) {
-            throw new Error('Pedidos de ajuda não encontrados');
-        }
-
-        return Helplist;
-    }
-
-    async getHelpListByStatus(id, status) {
-        const Helplist = await this.HelpRepository.listByStatus(id, status);
+    async getHelpList(id, status, except, helper) {
+        const Helplist = await this.HelpRepository.list(id, status, except, helper);
         if (!Helplist) {
             throw new Error('Pedidos de ajuda não encontrados');
         }


### PR DESCRIPTION
## Descrição 

Foram feitas mudanças nas queries da rota /help

## Tarefas gerais realizadas
* adicionar campo id.except, faz com que a query ajudas de todos os donos menos o com id passado
* adicionado campo id.helper, se passado a query fará a busca no banco procurando o id passado como helper id
* Além disso essa mesma rota procura por status caso passado na query
