### PR TITLE
Removing notification warning

### DIFF
--- a/src/utils/NotificationMixin.js
+++ b/src/utils/NotificationMixin.js
@@ -13,7 +13,10 @@ class NotificationService {
       body: body,
       _displayInForeground: true
     }
-
+    if(!message.to){
+      console.log("O usuário não possui deviceId")
+      return
+    }
     messages.push(message)
     
     try {


### PR DESCRIPTION
## Descrição 

Troca o warning de erro por um console log, quando a notificação falhar por falta de deviceId.

## Resolve (Issues)

[54](https://github.com/mia-ajuda/Documentation/issues/54)
