### PR TITLE
HOTFIX-ListNear

### DIFF
--- a/src/repository/HelpRepository.js
+++ b/src/repository/HelpRepository.js
@@ -173,10 +173,7 @@ class HelpRepository extends BaseRepository {
     matchQuery.ownerId = {
       $in: arrayUsersId,
     };
-    matchQuery = {
-      ...matchQuery,
-      $or: [{ status: "waiting" }, { helperId: ObjectId(id) }],
-    };
+    matchQuery.status = "waiting";
 
     if (categoryArray) {
       matchQuery.categoryId = {


### PR DESCRIPTION
## Descrição 

O listNear retorna apenas ajudas com status waiting.


## Tarefas gerais realizadas
* Foi alterado o matchQuery na listNear dentro da HelpRepository para procurar apenas ajudas com status wainting.

## Observação
* No front-end a parte de "minhas ofertas de ajuda" não precisa mais que o listNear retorne ajudas com status on_going.

