### PR TITLE
Documentação de Endpoints do Backend com Swagger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM node:12.2.0-alpine
 
+# Define o diretório de trabalho como /app
 WORKDIR /app
-
-COPY package*.json ./
-
-RUN yarn install
-
+# Copia os arquivos locais para o container
 COPY ./ ./
+# Instala as dependências do projeto
+RUN yarn install

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -6,8 +6,9 @@ info:
   termsOfService: None
   contact:
     name: Mia Ajuda
-    url: 'https://github.com/mia-ajuda'
-    
+    url: https://github.com/mia-ajuda
+servers:
+  - url: http://localhost:8000/api
 paths:
   /user:
     post:
@@ -46,7 +47,7 @@ paths:
       tags:
         - User
       operationId: GetApplicationById
-      description: Rota de obtenção de detalhes de uma aplicação por id
+      description: Rota para obter detalhes de um usuáiro por id
       parameters:
         - name: userId
           in: path
@@ -72,7 +73,52 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetailsResponse'
-  
+  /category:
+    get:
+      tags:
+        - Category
+      operationId: GetAllCategory
+      description: Rota para obter as categorias dos pedidos de ajuda
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CategoryResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+  /category/{id}:
+    get:
+      tags:
+        - Category
+      operationId: GetCategoryById
+      description: Rota para obter detalhes de uma categoria
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoryResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
 components:
   schemas:
     
@@ -140,7 +186,7 @@ components:
               type: string
             type:
               type: string
-              default: "Point"
+              default: Point
         groupRisc:
           type: array
           items: 
@@ -180,7 +226,23 @@ components:
         
     
     ############# End User ##############
+
+    ########## Start Category ###########
+
+    CategoryResponse:
+      type: object
+      properties:
+        _id:
+          type: string
+        active:
+          type: boolean
+        name:
+          type: string
+        description:
+          type: string
    
+    ########### End Category ###########
+
     ProblemDetailsResponse:
       type: object
       properties:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -239,6 +239,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GroupRiskResponse'
+  /checkUserExistence/{value}:  
+    get:
+      tags:
+        - User
+      operationId: checkUserExistence
+      description: Rota de verificação de existência de um usuário
+      parameters:
+        - name: value
+          in: path
+          required: true
+          schema:
+            type: string
+            description: Um email ou cpf do usuário.
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/checkUserExistenceResponse'
                 
   /category:
     get:
@@ -432,6 +452,31 @@ components:
     
     GroupRiskResponse:
       type: object
+      properties:
+        dc:
+          type: string
+          default: Doença respiratória
+          description: Doença respiratória
+        hiv: 
+          type: string
+          default: HIV
+          description: HIV
+        diab: 
+          type: string
+          default: Diabetes
+          description: Diabetes
+        hiperT: 
+          type: string
+          default: Hipertensão
+          description: Hipertensão
+        doenCardio: 
+          type: string
+          default: Doenças cardiovasculares
+          description: Doenças cardiovasculares
+          
+    checkUserExistenceResponse:
+      type: boolean
+        
     
     ############# End User ##############
 
@@ -457,11 +502,6 @@ components:
       type: object
       properties:
         error:
-          type: string
-    IdResponse:
-      type: object
-      properties:
-        id:
           type: string
           
     ############## Misc ################

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,0 +1,193 @@
+openapi: 3.0.0
+info:
+  version: v1
+  title: API MiaAjuda
+  description: API MiaAjuda
+  termsOfService: None
+  contact:
+    name: Mia Ajuda
+    url: 'https://github.com/mia-ajuda'
+    
+paths:
+  /user:
+    post:
+      tags:
+        - User
+      operationId: postUser
+      description: Rota de criação de usuário
+      parameters:
+        - name: hasUser
+          in: query
+          required: false
+          description: Parâmetro que indica se o usuário possui ou não um usuário. Só deve ser usado quando a conta for criada usando o Facebook ou gmail, onde o hasUser deve ser true
+          schema:
+            type: boolean
+            default: false
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PostUserRequest'
+      responses:
+        '201':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostUserResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+  /user/getUser/{userId}:
+    get:
+      tags:
+        - User
+      operationId: GetApplicationById
+      description: Rota de obtenção de detalhes de uma aplicação por id
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdResponse'
+        '404':
+          description: Aplicação não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+  
+components:
+  schemas:
+    
+    ############### User ################
+    
+    PostUserRequest:
+      type: object
+      properties:
+        groupRisc:
+          type: array
+          items: 
+            type: string
+        name: 
+          type: string
+        email: 
+          type: string
+        birthday:
+          type: string
+          format: date
+        cpf: 
+          type: string
+        photo: 
+          type: string
+        address:
+          type: object
+          properties:
+            cep: 
+              type: string
+            number: 
+              type: number
+            city: 
+              type: string
+            state: 
+              type: string
+            complement: 
+              type: string
+        password: 
+          type: string
+          minLength: 8
+        latitude: 
+          type: number
+        longitude: 
+          type: number
+        phone: 
+          type: string
+          minLength: 9
+    
+    PostUserResponse:
+      type: object
+      properties:
+        ismentalHealthProfessional: 
+          type: boolean
+        active: 
+          type: boolean
+        _id: 
+          type: string
+        location: 
+          type: object
+          properties:
+            coordinates: 
+              type: array
+              items:
+                type: number
+            id:
+              type: string
+            type:
+              type: string
+              default: "Point"
+        groupRisc:
+          type: array
+          items: 
+            type: string
+        name: 
+          type: string
+        email: 
+          type: string
+        birthday:
+          type: string
+          format: date
+        cpf: 
+          type: string
+        photo: 
+          type: string
+        address:
+          type: object
+          properties:
+            cep: 
+              type: string
+            number: 
+              type: number
+            city: 
+              type: string
+            state: 
+              type: string
+            complement: 
+              type: string
+        password: 
+          type: string
+        latitude: 
+          type: number
+        longitude: 
+          type: number
+        phone: 
+          type: string
+        
+    
+    ############# End User ##############
+   
+    ProblemDetailsResponse:
+      type: object
+      properties:
+        error:
+          type: string
+    IdResponse:
+      type: object
+      properties:
+        id:
+          type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -275,8 +275,20 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/CategoryResponse'
-        '400':
-          description: Bad Request
+        '401':
+          description: Usuário não autorizado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '403':
+          description: Usuário não está autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '404':
+          description: Aplicação não encontrada
           content:
             application/json:
               schema:
@@ -286,7 +298,7 @@ paths:
       tags:
         - Category
       operationId: GetCategoryById
-      description: Rota para obter detalhes de uma categoria
+      description: Rota para obter detalhes de uma categoria de pedido de ajuda
       parameters:
         - name: id
           in: path
@@ -300,12 +312,67 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CategoryResponse'
-        '400':
-          description: Bad Request
+        '401':
+          description: Usuário não autorizado
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetailsResponse'
+        '403':
+          description: Usuário não está autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '404':
+          description: Aplicação não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+
+  /notification/user/{id}:
+    get:
+      security:
+        - bearerAuth: []
+      tags:
+        - Notification
+      operationId: getAllUserNotifications
+      description: Rota para obter o histórico de todas as notificações recebidas por um determinado usuário
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Sucess
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NotificationResponse'
+        '401':
+          description: Usuário não autorizado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '403':
+          description: Usuário não está autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '404':
+          description: Aplicação não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+
 components:
   schemas:
     
@@ -495,6 +562,35 @@ components:
           type: string
    
     ########### End Category ###########
+
+    ######## Start Notification ########
+
+    NotificationResponse:
+      type: object
+      properties:
+        _id:
+          type: string
+        userId:
+          type: string
+        helpId:
+          type: string
+        title:
+          type: string
+        body:
+          type: string
+        registerDate:
+          type: string
+          format: date
+        notificationType:
+          type: string
+          enum:
+            - ajudaRecebida
+            - ajudaAceita
+            - ajudaFinalizada
+            - ajudaExpirada
+            - outros
+
+    ######### End Notification #########
     
     ############## Misc ################
 

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -287,6 +287,69 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetailsResponse'
+    get:
+      security:
+        - bearerAuth: []
+      tags:
+        - Help
+      operationId: getHelpByList
+      description: Rota de obtenção de ajudas próximas ou não
+      parameters:
+        - name: id.except
+          in: query
+          description: Caso queira obter as ajudas com exceção das que possuem o ajudante com o id especificado 
+          schema:
+            type: string
+        - name: id.helper
+          in: query
+          description: Caso queira obter as ajudas de um ajudante específico 
+          schema:
+            type: string
+        - name: status
+          in: query
+          description: Caso queira especificar o status das ajudas que serão retornadas 
+          schema:
+            type: string
+        - name: categoryId
+          in: query
+          description: Array de id de categorias separados por vírgula. 
+          schema:
+            type: string
+        - name: near
+          in: query
+          description: Booleano que indica se as ajudas devem estar próximas à determinada coordenada. Atributo obrigatório se coords for enviado.
+          schema:
+            type: boolean
+        - name: id.coords
+          in: query
+          description: Array de coordenadas separadas por vírgula.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetHelpListResponse'
+        '401':
+          description: Usuário não autorizado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '403':
+          description: Usuário não está autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '404':
+          description: Nenhum ajuda encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
   /help/{id}:
     get:
       security:
@@ -321,7 +384,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetailsResponse'
         '404':
-          description: Aplicação não encontrada
+          description: Ajuda não encontrada
           content:
             application/json:
               schema:
@@ -867,14 +930,57 @@ components:
           type: string
           format: date
         user:
-          type: object
           $ref: '#/components/schemas/PostUserResponse'
         category:
           type: array
           items:
-            type: object
             $ref: '#/components/schemas/CategoryResponse'
-
+    
+    GetHelpListResponse:
+      type: array
+      items:
+        type: object
+        properties:
+          _id:
+            type: string
+          status:
+            type: string
+          possibleHelpers:
+            type: array
+            items:
+              $ref: '#/components/schemas/PostUserResponse'
+          active:
+            type: boolean
+          title: 
+            type: string
+          description: 
+            type: string
+          categoryId: 
+            type: string
+          ownerId:
+            type: string
+          finishedDate:
+            type: string
+            format: date
+          creationDate:
+            type: string
+            format: date
+          user:
+            $ref: '#/components/schemas/PostUserResponse'
+          category:
+            type: array
+            items:
+              type: object
+              properties:
+                _id:
+                  type: string
+                active:
+                  type: string
+                name:
+                  type: string
+                description:
+                  type: string
+        
     GetHelpResponse:
       type: object
       properties:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -364,6 +364,174 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetailsResponse'
+  /help/possibleHelpers/{idHelp}/{idHelper}:
+    put:
+      security:
+        - bearerAuth: []
+      tags:
+        - Help
+      operationId: putPossibleHelpersById
+      description: Rota para inserção de possível ajudante (idHelper) em dada ajuda (idHelp)
+      parameters:
+        - name: idHelp
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: idHelper
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        '400':
+          description: Ocorreu um erro no processamento da solicitação
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '403':
+          description: Usuário não está autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '404':
+          description: Aplicação não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+  /help/chooseHelper/{idHelp}/{idHelper}:
+    put:
+      security:
+        - bearerAuth: []
+      tags:
+        - Help
+      operationId: putChooseHelperById
+      description: Rota para confirmação de escolha de um ajudante (idHelper) em uma dada ajuda (idHelp)
+      parameters:
+        - name: idHelp
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: idHelper
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success
+        '400':
+          description: Ocorreu um erro no processamento da solicitação
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '403':
+          description: Usuário não está autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '404':
+          description: Aplicação não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+  /help/helperConfirmation/{helpId}/{helperId}:
+    put:
+      security:
+        - bearerAuth: []
+      tags:
+        - Help
+      operationId: putHelperConfirmationById
+      description: Rota para confirmação de ajuda efetivada (helpId) por dado ajudante (helperId)
+      parameters:
+        - name: helpId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: helperId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetHelpResponse'
+        '400':
+          description: Ocorreu um erro no processamento da solicitação
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '403':
+          description: Usuário não está autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '404':
+          description: Aplicação não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+  /help/ownerConfirmation/{helpId}/{ownerId}:
+    put:
+      security:
+        - bearerAuth: []
+      tags:
+        - Help
+      operationId: putOwnerConfirmationById
+      description: Rota para confirmação de ajuda efetivada (helpId) pelo dono do pedido de ajuda (ownerId)
+      parameters:
+        - name: helpId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: ownerId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetHelpResponse'
+        '400':
+          description: Ocorreu um erro no processamento da solicitação
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '403':
+          description: Usuário não está autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '404':
+          description: Aplicação não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
 
   /category:
     get:
@@ -739,6 +907,9 @@ components:
           type: string
           format: date
         finishedDate:
+          type: string
+          format: date
+        helperId:
           type: string
           format: date
     

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -259,7 +259,112 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/checkUserExistenceResponse'
-                
+  
+  /help:
+    post:
+      security:
+        - bearerAuth: []
+      tags:
+        - Help
+      operationId: postHelp
+      description: Rota de criação de pedidos de ajuda
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PostHelpRequest'
+      responses:
+        '201':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostHelpResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+  /help/{id}:
+    get:
+      security:
+        - bearerAuth: []
+      tags:
+        - Help
+      operationId: getHelpById
+      description: Rota para obter detalhes de um pedido de ajuda pelo id
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetHelpResponse'
+        '401':
+          description: Usuário não autorizado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '403':
+          description: Usuário não está autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '404':
+          description: Aplicação não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+    delete:
+      security:
+        - bearerAuth: []
+      tags:
+        - Help
+      operationId: deleteHelpById
+      description: Rota para deletar uma pedido de ajuda pelo id
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/deleteHelpResponse'
+        '401':
+          description: Usuário não autorizado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '403':
+          description: Usuário não está autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '404':
+          description: Aplicação não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+
   /category:
     get:
       tags:
@@ -546,6 +651,105 @@ components:
         
     
     ############# End User ##############
+
+    ############ Start Help #############
+
+    PostHelpRequest:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        categoryId:
+          type: string
+        ownerId:
+          type: string
+      required: 
+        - title
+        - description
+        - categoryId
+        - ownerId
+    
+    PostHelpResponse:
+      type: object
+      properties:
+        _id:
+          type: string
+        status:
+          type: string
+          default: waiting
+        possibleHelpers:
+          type: array
+          default: []
+          items:
+            type: string
+        active:
+          type: boolean
+          default: true
+        title:
+          type: string
+        description:
+          type: string
+        categoryId:
+          type: string
+        ownerId:
+          type: string
+        creationDate:
+          type: string
+          format: date
+        user:
+          type: object
+          $ref: '#/components/schemas/PostUserResponse'
+        category:
+          type: array
+          items:
+            type: object
+            $ref: '#/components/schemas/CategoryResponse'
+
+    GetHelpResponse:
+      type: object
+      properties:
+        _id:
+          type: string
+        status:
+          type: string
+          enum:
+            - waiting
+            - on_going
+            - finished
+            - owner_finished
+            - helper_finished
+        possibleHelpers:
+          type: array
+          items:
+            type: string
+        active:
+          type: boolean
+          default: true
+        title:
+          type: string
+        description:
+          type: string
+        categoryId:
+          type: string
+        ownerId:
+          type: string
+        creationDate:
+          type: string
+          format: date
+        finishedDate:
+          type: string
+          format: date
+    
+    deleteHelpResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Help 5eb33263b863da00274ce1be deleted!
+
+    ############# End Help ##############
 
     ########## Start Category ###########
 

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -30,7 +30,7 @@ paths:
             schema:
               $ref: '#/components/schemas/PostUserRequest'
       responses:
-        '201':
+        '200':
           description: Success
           content:
             application/json:
@@ -42,12 +42,159 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetailsResponse'
-  /user/getUser/{userId}:
-    get:
+    put:
+      security:
+        - bearerAuth: []
       tags:
         - User
-      operationId: GetApplicationById
-      description: Rota para obter detalhes de um usuáiro por id
+      operationId: putUser
+      description: Rota de edição de usuário
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PutUserRequest'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostUserResponse'
+        '401':
+          description: Usuário não autorizado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '403':
+          description: Usuário não está autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '404':
+          description: Aplicação não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+    delete:
+      security:
+        - bearerAuth: []
+      tags:
+        - User
+      operationId: deleteUser
+      description: Rota de deleção lógica de usuário
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostUserResponse'
+        '401':
+          description: Usuário não autorizado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '403':
+          description: Usuário não está autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '404':
+          description: Aplicação não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+  '/user/adress':
+    put:
+      security:
+        - bearerAuth: []
+      tags:
+        - User
+      operationId: putUserAdress
+      description: Rota de edição de endereço do usuário
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PutUserAdressRequest'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostUserResponse'
+        '401':
+          description: Usuário não autorizado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '403':
+          description: Usuário não está autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '404':
+          description: Aplicação não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+  '/user/location':
+    put:
+      security:
+        - bearerAuth: []
+      tags:
+        - User
+      operationId: putUserLocation
+      description: Rota de edição de localização do usuário
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PutUserLocationRequest'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostUserResponse'
+        '401':
+          description: Usuário não autorizado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '403':
+          description: Usuário não está autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '404':
+          description: Aplicação não encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+  /user/getUser/{userId}:
+    get:
+      security:
+        - bearerAuth: []
+      tags:
+        - User
+      operationId: GetUserByIdOrToken
+      description: Rota para obter detalhes de um usuário por id
       parameters:
         - name: userId
           in: path
@@ -60,19 +207,39 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IdResponse'
+                $ref: '#/components/schemas/PostUserResponse'
+        '401':
+          description: Usuário não autorizado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
+        '403':
+          description: Usuário não está autenticado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsResponse'
         '404':
           description: Aplicação não encontrada
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetailsResponse'
-        '500':
-          description: Internal server error
+  /groupRisk:  
+    get:
+      tags:
+        - User
+      operationId: getGroupRisk
+      description: Rota de obtenção da lista de grupos de risco
+      responses:
+        '200':
+          description: Success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProblemDetailsResponse'
+                $ref: '#/components/schemas/GroupRiskResponse'
+                
   /category:
     get:
       tags:
@@ -165,7 +332,46 @@ components:
         phone: 
           type: string
           minLength: 9
+      required: 
+        - name
+        - email
+        - cpf
+        - password
     
+    PutUserRequest:
+      type: object
+      properties:
+        photo: 
+          type: string
+        name: 
+          type: string
+        notificationToken: 
+          type: string
+        deviceId:
+          type: string
+          
+    PutUserLocationRequest:
+      type: object
+      properties:
+        latutide: 
+          type: number
+        longitude: 
+          type: number
+    
+    PutUserAdressRequest:
+      type: object
+      properties:
+        cep: 
+          type: string
+        number: 
+          type: string
+        city: 
+          type: string
+        state: 
+          type: string
+        complement:
+          type: string
+          
     PostUserResponse:
       type: object
       properties:
@@ -223,7 +429,9 @@ components:
           type: number
         phone: 
           type: string
-        
+    
+    GroupRiskResponse:
+      type: object
     
     ############# End User ##############
 
@@ -242,6 +450,8 @@ components:
           type: string
    
     ########### End Category ###########
+    
+    ############## Misc ################
 
     ProblemDetailsResponse:
       type: object
@@ -253,3 +463,11 @@ components:
       properties:
         id:
           type: string
+          
+    ############## Misc ################
+    
+  securitySchemes:
+    bearerAuth:            
+      type: http
+      scheme: bearer
+      bearerFormat: JWT   

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "lodash": "^4.17.15",
     "mongoose": "^5.9.6",
     "node-schedule": "^1.3.2",
-    "socket.io": "^2.3.0"
+    "socket.io": "^2.3.0",
+    "swagger-ui-express": "^4.1.4",
+    "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/src/controllers/UserController.js
+++ b/src/controllers/UserController.js
@@ -93,7 +93,7 @@ class UserController {
             res.status(200).json(result);
             next();
         } catch (err) {
-            res.status(400).json({ error: err });
+            res.status(404).json({ error: err });
             next();
         }
     }
@@ -122,15 +122,15 @@ class UserController {
             res.status(200).json(result);
             next();
         } catch (err) {
-            res.status(400).json({ error: err });
+            res.status(404).json({ error: err });
             next();
         }
     }
 
-  async getUserGroupRiskList(req, res, next) {
-    res.status(200).json(riskGroups);
-    next();
-  }
+    async getUserGroupRiskList(req, res, next) {
+        res.status(200).json(riskGroups);
+        next();
+    }
 }
 
 module.exports = UserController;

--- a/src/routes/BaseRoutes.js
+++ b/src/routes/BaseRoutes.js
@@ -3,6 +3,11 @@ const helpRoutes = require('./HelpRoutes');
 const categoryRoutes = require('./CategoryRoutes');
 const notificationRoutes = require('./NotificationRoutes');
 
+const YAML = require('yamljs');
+const swaggerUi = require('swagger-ui-express');
+const swaggerDocument = YAML.load('docs/swagger.yaml');
+
 module.exports = (app) => {
+    app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
     app.use('/api', [userRoutes, helpRoutes, categoryRoutes, notificationRoutes]);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1622,7 +1622,7 @@ glob-parent@^5.0.0, glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.1.3:
+glob@^7.0.5, glob@^7.1.3:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -3583,6 +3583,18 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+swagger-ui-dist@^3.18.1:
+  version "3.25.1"
+  resolved "https://registry.yarnpkg.com/swagger-ui-dist/-/swagger-ui-dist-3.25.1.tgz#8aa9c3217849722f6d8c7fac6b2222f9082227bb"
+  integrity sha512-Sw/K95j1pT9TZtLKiHDEml7YqcXC9thTTQjxrvNgd9j1KzOIxpo/5lhHuUMAN/hxVAHetzmcBcQaBjywRXog8w==
+
+swagger-ui-express@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/swagger-ui-express/-/swagger-ui-express-4.1.4.tgz#8b814ad998b850a1cf90e71808d6d0a8a8daf742"
+  integrity sha512-Ea96ecpC+Iq9GUqkeD/LFR32xSs8gYqmTW1gXCuKg81c26WV6ZC2FsBSPVExQP6WkyUuz5HEiR0sEv/HCC343g==
+  dependencies:
+    swagger-ui-dist "^3.18.1"
+
 table@^5.2.3:
   version "5.4.6"
   resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
@@ -3970,6 +3982,14 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yamljs@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/yamljs/-/yamljs-0.3.0.tgz#dc060bf267447b39f7304e9b2bfbe8b5a7ddb03b"
+  integrity sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==
+  dependencies:
+    argparse "^1.0.7"
+    glob "^7.0.5"
 
 yeast@0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Descrição 

O atual _Pull Request_ adiciona a documentação dos endpoints do backend através do `swagger.io`.

### Instruções de Uso

Para utilizar o swagger, prossiga com os passos abaixo:
1. Suba o backend através do comando `sudo docker-compose up --build`;
2. Acesse o swagger pelo navegador: `http://localhost:8000/api-docs/`;
3. Utilize a interface do swagger para verificar os formatos de _request_ e _response_ das rotas e realizar requisições.

* Observação: caso a rota a ser explorada necessite de autenticação, obtenha o token e preencha-o no campo "_Authorize_".

## Resolve (Issues)

Não há issues ou histórias de usuário relacionadas a esse _pull request_.

## Tarefas gerais realizadas

- [x] Documentado no swagger endpoint para notificações;
- [x] Documentado no swagger endpoint para categorias;
- [x] Documentado no swagger endpoint para usuários;
- [x] Documentado no swagger endpoint para ajudas.