### PR TITLE
Hotfix-LimiteAjudas

### DIFF
--- a/src/repository/HelpRepository.js
+++ b/src/repository/HelpRepository.js
@@ -290,6 +290,7 @@ class HelpRepository extends BaseRepository {
     const query = {};
     query.ownerId = id;
     query.active = true;
+    query.status = {$ne:"finished"};
     const result = await super.$countDocuments(query);
 
     return result;


### PR DESCRIPTION
## Descrição 

Havia um erro no limite de ajudas, no qual ajudas com status finished também eram contabilizadas,
assim o usuário poderia ter no máximo 5 ajudas contanto com ajudas finalizadas e não finalizadas.

## Tarefas gerais realizadas
* Agora o countDocuments só conta ajudas com status diferente de finished, como "on_going","waiting","owner_finished","helper_finished".

## Observações
* Este pull request deve ser aceito após o pull request do Hotfix-notifications.

