### PR TITLE
Hotfix-categorySocket

### DIFF
--- a/websocket.js
+++ b/websocket.js
@@ -18,7 +18,6 @@ exports.setupWebsocket = (server) => {
       categories: [],
     });
 
-
     socket.on('change-locations', (locations) => {
       const index = connections.map((connection) => connection.id).indexOf(socket.id);
       if (index >= 0) {
@@ -30,6 +29,9 @@ exports.setupWebsocket = (server) => {
       const index = connections.map((connection) => connection.id).indexOf(socket.id);
       if (index >= 0) {
         connections[index].categories = categories;
+        console.log('abacaxi');
+        console.log(connections[index]);
+        console.log('--------------------------')
       }
     });
 
@@ -52,15 +54,25 @@ function canParse(locs) {
 }
 exports.findConnections = (coordinates, category, userId) => {
   const filtered = connections.filter((connection) => {
+    console.log(connection);
     if (userId === connection.userId) {
       return false;
     }
+    console.log(1);
     if (connection.categories && connection.categories.length) {
       const { categories } = connection;
-      if (!categories.includes(category)) {
+      let categoryExist = false;
+      for (let i = 0; i < categories.length; i = 1 + 1) {
+        if (categories[i] == category) {
+          categoryExist = true;
+          break;
+        }
+      }
+      if (!categoryExist) {
         return false;
       }
     }
+    console.log(4);
     let should = false;
     let locs = connection.locations;
     if (canParse(locs)) {

--- a/websocket.js
+++ b/websocket.js
@@ -29,9 +29,6 @@ exports.setupWebsocket = (server) => {
       const index = connections.map((connection) => connection.id).indexOf(socket.id);
       if (index >= 0) {
         connections[index].categories = categories;
-        console.log('abacaxi');
-        console.log(connections[index]);
-        console.log('--------------------------')
       }
     });
 
@@ -57,7 +54,6 @@ exports.findConnections = (coordinates, category, userId) => {
     if (userId === connection.userId) {
       return false;
     }
-    console.log(1);
     if (connection.categories && connection.categories.length) {
       const { categories } = connection;
       let categoryExist = false;
@@ -71,7 +67,6 @@ exports.findConnections = (coordinates, category, userId) => {
         return false;
       }
     }
-    console.log(4);
     let should = false;
     let locs = connection.locations;
     if (canParse(locs)) {

--- a/websocket.js
+++ b/websocket.js
@@ -54,7 +54,6 @@ function canParse(locs) {
 }
 exports.findConnections = (coordinates, category, userId) => {
   const filtered = connections.filter((connection) => {
-    console.log(connection);
     if (userId === connection.userId) {
       return false;
     }

--- a/websocket.js
+++ b/websocket.js
@@ -62,7 +62,7 @@ exports.findConnections = (coordinates, category, userId) => {
     if (connection.categories && connection.categories.length) {
       const { categories } = connection;
       let categoryExist = false;
-      for (let i = 0; i < categories.length; i = 1 + 1) {
+      for (let i = 0; i < categories.length; i += 1) {
         if (categories[i] == category) {
           categoryExist = true;
           break;


### PR DESCRIPTION
## Descrição 

Havia um bug no qual quando o usuário A estava com o filtro ligado(filtrou para ver apenas ajudas de higiene pessoal por exemplo), se uma ajuda fosse criada por outro usuário B com a mesma categoria que o usuário A filtrou, esssa ajuda não aparecia no mapa do usuário A. Havia um problema com comparação de tipos que foi resolvida. Agora este problema não ocorre mais.

## Tarefas gerais realizadas
* Troca-se o includes por um for.

