### PR TITLE
[US100] Rotina para Backup da Base de Dados

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ dist
 
 # package-lock (main is yarn.lock)
 package-lock.json
+
+# Arquivo de configuração de backup remoto
+rclone.conf

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ build:
     IMAGE_NAME: "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG"
   before_script:
     - cat $FIREBASE_CONFIG > ./src/config/firebaseAuthConfig.js
+    - cat $RCLONE_CONFIG > ./config/rclone.conf
   script:
     - echo "Building image"
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
@@ -40,6 +41,7 @@ build stable:
     IMAGE_NAME: "$CI_REGISTRY_IMAGE:stable"
   before_script:
     - cat $FIREBASE_CONFIG > ./src/config/firebaseAuthConfig.js
+    - cat $RCLONE_CONFIG > ./config/rclone.conf
   script:
     - echo "Building image"
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 </p>
 
 <p align="center">
-<a href="https://play.google.com/store/apps/details?id=com.unb.miaajuda" target="_blank"><img src="https://img.shields.io/badge/Mia%20Ajuda-Google%20Play-yellow"></a>
-<a href="https://miaajuda.netlify.app/" target="_blank"><img src="https://img.shields.io/badge/Mia%20Ajuda-Website-blue"></a>
-<a href="https://mia-ajuda.github.io/Documentation/#/" target="_blank"><img src="https://img.shields.io/badge/Mia%20Ajuda-Docs-purple"></a>
-<a href="https://github.com/mia-ajuda/Backend/pulls" target="_blank"><img src="https://img.shields.io/github/issues-pr/mia-ajuda/Backend?color=red&label=Pull%20Requests"></a>
+  <a href="https://play.google.com/store/apps/details?id=com.unb.miaajuda" target="_blank" alt="Mia Ajuda na Google Play"><img src="https://img.shields.io/badge/Mia%20Ajuda-Google%20Play-yellow"></a>
+  <a href="https://miaajuda.netlify.app/" target="_blank" alt="Mia Ajuda Website"><img src="https://img.shields.io/badge/Mia%20Ajuda-Website-blue"></a>
+  <a href="https://mia-ajuda.github.io/Documentation/#/" target="_blank" alt="Mia Ajuda Documentação"><img src="https://img.shields.io/badge/Mia%20Ajuda-Docs-purple"></a>
+  <a href="https://github.com/mia-ajuda/Backend/pulls" target="_blank" alt="Mia Ajuda Pull Requests"><img src="https://img.shields.io/github/issues-pr/mia-ajuda/Backend?color=red&label=Pull%20Requests"></a>
 </p>
 
 ## Rode o Backend com Docker
@@ -52,9 +52,13 @@ LONGITUDE_ENV=
 SENTRY_DSN=
 NODE_ENV=development
 DATABASE_URL=mongodb://mongo/miaAjudaDB
+MONGODB_USERNAME=
+MONGODB_PASSWORD=
 ```
 
-* O preenchimento do serviço de monitoramento de erros ([Sentry](https://sentry.io/)) é opcional. A latitude e a longitude serão utilizadas para popular exemplos de pedido de ajuda próximos a essa coordenada.
+* O preenchimento do serviço de monitoramento de erros ([Sentry](https://sentry.io/)) é opcional.
+* A latitude e a longitude serão utilizadas para popular exemplos de pedido de ajuda próximos a essa coordenada.
+* As variáveis de ambiente `MONGODB_USERNAME` e `MONGODB_PASSWORD` destinam-se ao acesso da base de dados com autenticação. Ver detalhes de configuração de backup abaixo.
 
 ### Inicialização do Projeto
 
@@ -72,3 +76,25 @@ sudo docker-compose -f docker-compose.yml up --build
 2. Na raiz do projeto, verifique a corretude do código com `eslint . --ext .js`; ou
 3. Configure uma extensão no seu editor de texto preferido (exemplo: [VSCode - ESLINT](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint));
 4. Abra o seu editor de texto na raiz do projeto `/Backend` e comece a desenvolver.
+
+### Backup da Base de Dados
+
+A aplicação realiza backups da base "miaAjudaDB" regularmente às 04h da manhã. O serviço guarda um total de 14 backups locais e sempre salva o backup no Google Drive. Para isso ser possível, proceda com as instruções:
+
+#### Configuração do Backup
+
+1. Preencha adequadamente as variáveis de ambiente do tópico "Arquivos de Configuração";
+2. Salve na pasta `/Backend/config/` o arquivo `rclone.conf`;
+3. Em produção, inicie os serviços de backend, banco e backup com:
+
+```sh
+sudo docker-compose -f docker-compose.yml -f docker-compose.prod.yml up
+```
+
+#### Restauração do Backup
+
+1. Para realizar a restauração de um backup, proceda com o comando:
+
+```sh
+mongorestore --gzip --archive=backup-scheduler-1594607580.gz --drop
+```

--- a/config/backup-scheduler.yaml
+++ b/config/backup-scheduler.yaml
@@ -1,0 +1,24 @@
+scheduler:
+  # run every day at 4:00 UTC-3
+  cron: "0 7 */1 * *"
+  # number of backups to keep locally
+  retention: 14
+  # backup operation timeout in minutes
+  timeout: 60
+target:
+  # mongod IP or host name
+  host: "mongo"
+  # mongodb port
+  port: 27017
+  # mongodb database name, leave blank to backup all databases
+  database: "miaAjudaDB"
+  # leave blank if auth is not enabled
+  username: ${MONGODB_USERNAME}
+  password: ${MONGODB_PASSWORD}
+  # add custom params to mongodump (eg. Auth or SSL support), leave blank if not needed
+  params: "--authenticationDatabase admin" # "--ssl"
+rclone:
+  bucket: "MiaAjuda-Rclone"
+  # See https://rclone.org/docs/ for details on how to configure rclone
+  configFilePath: /config/rclone.conf
+  configSection: "MiaAjuda-Rclone"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,16 @@
+version: "3"
+services:
+    mgob:
+        container_name: mgob
+        environment:
+            - MONGODB_USERNAME=${MONGODB_USERNAME}
+            - MONGODB_PASSWORD=${MONGODB_PASSWORD}
+        image: stefanprodan/mgob:edge
+        command: ./mgob -LogLevel=info
+        volumes:
+            - ./config:/config
+            - /mgob/storage:/storage
+            - /mgob/tmp:/tmp
+            - /mgob/data:/data
+        depends_on:
+            - mongo


### PR DESCRIPTION
## Descrição 

Com o incremento do atual pull request, haverá um serviço na aplicação que realizará backups da base de dados `miaAjudaDB` regularmente às 04h da manhã. O serviço guardará um total de 14 backups locais e sempre salvará o backup no Google Drive de desenvolvimento do projeto (credenciais no drive principal).

## Resolve (Issues)

[US100](https://github.com/mia-ajuda/Documentation/issues/100)

## Tarefas gerais realizadas

- [x] Backup local da base de dados "miaAjudaDB" com persistência de 14 dias;
- [x] Backup diário para o Google Drive de desenvolvimento do projeto;
- [x] Documentar utilização do serviço de backup e restauração no `README.md`;
- [x] Adicionar credenciais e arquivos de configuração no Google Drive principal do projeto.

## Lembretes

- [x] Colocar novas variáveis de ambiente no GitLab.
- [x] Adicionar arquivo de configuração do rclone no GitLab.