### PR TITLE
Adding firebase dev to the ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,7 @@ build:
   variables:
     IMAGE_NAME: "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG"
   before_script:
+    - cat $FIREBASE_CONFIG_DEV > ./src/config/fibaseConfig-dev.js
     - cat $FIREBASE_CONFIG > ./src/config/fibaseConfig.js
   script:
     - echo "Building image"
@@ -48,5 +49,3 @@ build stable:
   only:
     - master
     - configuracao-ci
-
-


### PR DESCRIPTION
## Descrição 

Hotfix para incluir a variável de ambiente do firebase de dev no CI de produção

## Tarefas gerais realizadas
* Adição da variável de ambiente de dev para o firebase e script para recuperar o arquivo de dev para o projeto. 
