### PR TITLE
[Feature] Help Categories

### DIFF
--- a/src/repository/HelpRepository.js
+++ b/src/repository/HelpRepository.js
@@ -35,7 +35,7 @@ class HelpRepository extends BaseRepository {
           from: 'category',
           localField: 'categoryId',
           foreignField: '_id',
-          as: 'category',
+          as: 'categories',
         },
       },
     ];
@@ -141,7 +141,7 @@ class HelpRepository extends BaseRepository {
           from: 'category',
           localField: 'categoryId',
           foreignField: '_id',
-          as: 'category',
+          as: 'categories',
         },
       },
       {
@@ -202,7 +202,7 @@ class HelpRepository extends BaseRepository {
           from: 'category',
           localField: 'categoryId',
           foreignField: '_id',
-          as: 'category',
+          as: 'categories',
         },
       },
       {
@@ -305,7 +305,7 @@ class HelpRepository extends BaseRepository {
           from: 'category',
           localField: 'categoryId',
           foreignField: '_id',
-          as: 'category',
+          as: 'categories',
         },
       },
       {

--- a/src/repository/HelpRepository.js
+++ b/src/repository/HelpRepository.js
@@ -205,12 +205,7 @@ class HelpRepository extends BaseRepository {
           preserveNullAndEmptyArrays: false,
         },
       },
-      {
-        $unwind: {
-          path: '$category',
-          preserveNullAndEmptyArrays: false,
-        },
-      },
+
     ]);
     return helpList;
   }

--- a/src/services/HelpService.js
+++ b/src/services/HelpService.js
@@ -19,7 +19,6 @@ class HelpService {
 
   async createHelp(data) {
     const countHelp = await this.HelpRepository.countDocuments(data.ownerId);
-    console.log(countHelp);
     if (countHelp >= 5) {
       throw new Error('Limite máximo de pedidos atingido');
     }


### PR DESCRIPTION
## Descrição 

Foi criado as páginas e lógicas para a adição de mais de uma categoria em uma oferta/pedido de ajuda. Agora, pode-se criar mais de uma categoria para uma ajuda; Limite de 3 categorias;

## Resolve (Issues)
[#118](https://github.com/mia-ajuda/Documentation/issues/118) - Categorizar ofertas

## PRs relacionados, se houver

branch | PR
118-helpCategory (Frontend) | [#110](https://github.com/mia-ajuda/Frontend/pull/110)

## Tarefas gerais realizadas
* Troca no schema de oferta de ajuda e ajuda para receber mais de uma categoria 

Teste: 
 - Suba o backend na branch 118-HelpCategory;
- No frontend use a brach 118-HelpCategory, crie uma oferta de ajuda e uma ajuda. Selecione mais de uma categoria;
- No app, na página de meus pedidos, verifique se sua ajuda foi criada e se possui mais de uma categoria;
- Obs, testar, também o filtro por categoria no mapa; 
