### PR TITLE
Retirar validade da ajuda

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const http = require('http');
 const Sentry = require('@sentry/node');
 const sentryInit = require('./src/config/sentryConfig');
 const setRoutes = require('./src/routes/BaseRoutes');
-const dailySchedule = require('./src/utils/schedule');
+// const dailySchedule = require('./src/utils/schedule');
 const { setupWebsocket } = require('./websocket');
 
 const app = express();
@@ -23,7 +23,7 @@ app.use(cors());
 app.use(bodyParser.json());
 
 databaseConnect();
-dailySchedule();
+// dailySchedule();
 setRoutes(app);
 
 app.use(Sentry.Handlers.errorHandler());


### PR DESCRIPTION
## Descrição 

Foi comentado o cron que verifica se uma ajuda é antiga e deleta ela, assim as ajudas vão ficar no mapa indefinitivamente

## Resolve (Issues)

[#161](https://github.com/mia-ajuda/Documentation/issues/161)

## Tarefas gerais realizadas
* Comentar cron

# Cuidado :skull_and_crossbones: 
### O PR vai direto para a master, se for aceito deve inicar o deploy automatico
