### PR TITLE
[HotFix] - Rota para retornar somente próprias ajudas

### DIFF
--- a/src/controllers/HelpOfferController.js
+++ b/src/controllers/HelpOfferController.js
@@ -28,10 +28,10 @@ class OfferedHelpController {
   }
 
   async listHelpsOffersByOwnerId(req, res) {
-    const { ownerId } = req.params;
+    const { id } = req.params;
     try {
       const helpOffers = await this.HelpOfferService.listHelpsOffersByOwnerId(
-        ownerId
+        id
       );
       return res.json(helpOffers);
     } catch (error) {

--- a/src/routes/HelpOfferRoutes.js
+++ b/src/routes/HelpOfferRoutes.js
@@ -12,7 +12,7 @@ routes.get('/helpOffer/list', isAuthenticated, (req, res, next) => {
   helpOfferController.listHelpsOffers(req, res, next);
 });
 
-routes.get('/helpOffer/list/:ownerId', isAuthenticated, (req, res, next) => {
+routes.get('/helpOffer1/list/:id', isAuthenticated, (req, res, next) => {
   helpOfferController.listHelpsOffersByOwnerId(req, res, next);
 });
 


### PR DESCRIPTION
## Descrição 
- Foi arrumada a rota para retorna somente as ofertas de ajuda do próprio usuário. 

## Atenção

- E esse PR deve ser aceito **junto** com o [44-history](https://github.com/mia-ajuda/Frontend/pull/123) 