### PR TITLE
HOTFIX - Listagem de ongs como possíveis ajudantes.

### DIFF
--- a/src/repository/HelpRepository.js
+++ b/src/repository/HelpRepository.js
@@ -108,6 +108,14 @@ class HelpRepository extends BaseRepository {
       },
       {
         $lookup: {
+          from: 'entity',
+          localField: 'possibleEntities',
+          foreignField: '_id',
+          as: 'possibleEntities',
+        },
+      },
+      {
+        $lookup: {
           from: 'user',
           localField: 'ownerId',
           foreignField: '_id',
@@ -295,7 +303,7 @@ class HelpRepository extends BaseRepository {
       },
       ...possibleHelpersEntityArray,
       ...sharedAgreggationInfo,
-     ];
+    ];
     // Caso seja os meus pedidos você quer ver os possíveis ajudantes e o helperId
     if (showPossibleHelpers) {
       aggregation[aggregation.length - 1].$project.possibleHelpers = {


### PR DESCRIPTION
## Descrição 

O dono da ajuda não conseguia ver as ongs que tentavam lhe ajudar. O que tava acontecendo era que faltava o `$lookup` para recuperar os `possibleEntities` do banco de dados.

## Resolve (Issues)

- https://github.com/mia-ajuda/Documentation/issues/189

## Como testar
- Crie uma ajuda.
- Com uma conta de organização, se ofereça a ajudar.
- Veja se a organização aparece na lista de possiveis ajudantes da ajuda.

## Tarefas gerais realizadas
* A ajuda foi populada com os `possibleEntities`
