### PR TITLE
Hotfix - Filtro de ajuda/oferta da Instituição já candidatada

### DIFF
--- a/src/controllers/HelpController.js
+++ b/src/controllers/HelpController.js
@@ -41,6 +41,7 @@ class HelpController {
 
   async getHelpList(req, res, next) {
     const { id } = req.query;
+    const isUserEntity = global.isUserEntity;
     const coords = req.query.coords.split(',').map((coord) => Number(coord));
     const categoryArray = req.query.categoryId ? req.query.categoryId.split(',') : null;
     /* A requisição do Query é feita com o formato "34312ID12312,12312ID13213",
@@ -49,6 +50,7 @@ class HelpController {
       const result = await this.HelpService.getHelpList(
         coords,
         id,
+        isUserEntity,
         categoryArray,
       );
       res.status(200);

--- a/src/controllers/HelpOfferController.js
+++ b/src/controllers/HelpOfferController.js
@@ -34,8 +34,9 @@ class OfferedHelpController {
   async listHelpsOffers(req, res) {
     const userId = req.query.userId;
     const getOtherUsers = req.query.getOtherUsers == 'true' ? true : false;
+    const isUserEntity = global.isUserEntity;
     try {
-      const helpOffers = await this.HelpOfferService.listHelpsOffers(userId, null, getOtherUsers);
+      const helpOffers = await this.HelpOfferService.listHelpsOffers(userId, isUserEntity, null, getOtherUsers);
       return res.json(helpOffers);
     } catch (error) {
       return res.status(400).json({ error: error.message });

--- a/src/repository/HelpOfferRepository.js
+++ b/src/repository/HelpOfferRepository.js
@@ -87,8 +87,13 @@ class OfferdHelpRepository extends BaseRepository {
   getHelpOfferListQuery(userId, active, getOtherUsers, categoryArray) {
     var matchQuery = { active };
     if (!getOtherUsers) {
-      matchQuery.possibleHelpedUsers = { $not: { $in: [ObjectID(userId)] } };
       matchQuery.ownerId = { $ne: ObjectID(userId) };
+      
+      if(global.isUserEntity){
+        matchQuery.possibleEntities = { $nin: [ObjectID(userId)] };
+      }else{
+        matchQuery.possibleHelpedUsers = { $nin: [ObjectID(userId)] };
+      }
     } else {
       matchQuery.ownerId = { $eq: ObjectID(userId) };
     }

--- a/src/repository/HelpOfferRepository.js
+++ b/src/repository/HelpOfferRepository.js
@@ -54,9 +54,10 @@ class OfferdHelpRepository extends BaseRepository {
     return super.$findOne(query, helpOfferFields, populate);
   }
 
-  async list(userId, categoryArray, getOtherUsers) {
+  async list(userId, isUserEntity, categoryArray, getOtherUsers) {
     const matchQuery = this.getHelpOfferListQuery(
       userId,
+      isUserEntity,
       true,
       getOtherUsers,
       categoryArray
@@ -84,12 +85,12 @@ class OfferdHelpRepository extends BaseRepository {
 
     return super.$list(matchQuery, helpOfferFields, populate, sort);
   }
-  getHelpOfferListQuery(userId, active, getOtherUsers, categoryArray) {
+  getHelpOfferListQuery(userId, isUserEntity, active, getOtherUsers, categoryArray) {
     var matchQuery = { active };
     if (!getOtherUsers) {
       matchQuery.ownerId = { $ne: ObjectID(userId) };
       
-      if(global.isUserEntity){
+      if(isUserEntity){
         matchQuery.possibleEntities = { $nin: [ObjectID(userId)] };
       }else{
         matchQuery.possibleHelpedUsers = { $nin: [ObjectID(userId)] };

--- a/src/repository/HelpRepository.js
+++ b/src/repository/HelpRepository.js
@@ -71,14 +71,14 @@ class HelpRepository extends BaseRepository {
     await super.$update(help);
   }
 
-  async shortList(coords, id, categoryArray) {
+  async shortList(coords, id, isUserEntity, categoryArray) {
     const matchQuery = {
       active: true,
       ownerId: { $ne: ObjectID(id) },
       status: 'waiting'
     };
 
-    if(global.isUserEntity){
+    if(isUserEntity){
       matchQuery.possibleEntities = { $nin: [ObjectID(id)] };
     }else{
       matchQuery.possibleHelpers = { $nin: [ObjectID(id)] };

--- a/src/repository/HelpRepository.js
+++ b/src/repository/HelpRepository.js
@@ -74,10 +74,15 @@ class HelpRepository extends BaseRepository {
   async shortList(coords, id, categoryArray) {
     const matchQuery = {
       active: true,
-      possibleHelpers: { $not: { $in: [ObjectID(id)] } },
-      ownerId: { $not: { $in: [ObjectID(id)] } },
+      ownerId: { $ne: ObjectID(id) },
       status: 'waiting'
     };
+
+    if(global.isUserEntity){
+      matchQuery.possibleEntities = { $nin: [ObjectID(id)] };
+    }else{
+      matchQuery.possibleHelpers = { $nin: [ObjectID(id)] };
+    }
 
     if (categoryArray) {
       matchQuery.categoryId = {

--- a/src/services/HelpOfferService.js
+++ b/src/services/HelpOfferService.js
@@ -3,7 +3,6 @@ const UserService = require("./UserService");
 const EntityService = require("./EntityService");
 const NotificationService = require("./NotificationService");
 const NotificationMixin = require("../utils/NotificationMixin");
-const isEntity = require('../utils/IsEntity');
 const { notificationTypesEnum } = require("../models/Notification");
 const saveError = require('../utils/ErrorHistory');
 const { findConnections, sendMessage } = require("../../websocket");
@@ -35,8 +34,8 @@ class OfferedHelpService {
     return help;
   }
 
-  async listHelpsOffers(userId, categoryArray, getOtherUsers) {
-    const helpOffers = await this.OfferedHelpRepository.list(userId, categoryArray, getOtherUsers);
+  async listHelpsOffers(userId, isUserEntity, categoryArray,getOtherUsers) {
+    const helpOffers = await this.OfferedHelpRepository.list(userId, isUserEntity, categoryArray,getOtherUsers);
     return helpOffers;
   }
 

--- a/src/services/HelpService.js
+++ b/src/services/HelpService.js
@@ -57,10 +57,11 @@ class HelpService {
     return Help;
   }
 
-  async getHelpList(coords, id, categoryArray) {
+  async getHelpList(coords, id, isUserEntity, categoryArray) {
     const Helplist = await this.HelpRepository.shortList(
       coords,
       id,
+      isUserEntity,
       categoryArray
     );
     if (!Helplist) {


### PR DESCRIPTION
## Descrição 

Antes, as ajudas/ofertas eram retornadas sem filtrar se a instituição já foi candidatado. Agora, está ocorrendo esse filtro.

## Como testar

1.  Entre com uma conta de instituição
2. Se candidate para varias ofertas/ajudas.
3. Dê o reload ou reentre na aplicação.
4. Note que as ofertas/ajudas já candidatadas não são mostradas no mapa.
 
## Resolve (Issues)

- https://github.com/mia-ajuda/Documentation/issues/202

## Tarefas gerais realizadas
* Adição do filtro de instituição já candidatada
