### PR TITLE
214 - Abrir whatsapp para pedidos

### DIFF
--- a/src/services/HelpService.js
+++ b/src/services/HelpService.js
@@ -238,7 +238,7 @@ class HelpService {
       helper = await this.EntityService.getEntity({ id: help.helperId });
     }
 
-    if (help.ownerId !== data.ownerId) {
+    if (help.ownerId != data.ownerId) {
       throw new Error('Usuário não é o dono da ajuda');
     } else if (help.status === 'helper_finished') {
       const ownerTitle = 'Pedido de ajuda finalizado!';

--- a/src/services/HelpService.js
+++ b/src/services/HelpService.js
@@ -237,8 +237,7 @@ class HelpService {
     } catch (e) {
       helper = await this.EntityService.getEntity({ id: help.helperId });
     }
-
-    if (help.ownerId != data.ownerId) {
+    if (help.ownerId.toString() !== data.ownerId) {
       throw new Error('Usuário não é o dono da ajuda');
     } else if (help.status === 'helper_finished') {
       const ownerTitle = 'Pedido de ajuda finalizado!';


### PR DESCRIPTION
## Descrição 

Resolve bug no qual disparava erro ao comparar o owner id do pedido com a owner id enviado na request.  

## Resolve (Issues)

[Abrir whatsapp para pedidos e ofertas #214](https://github.com/mia-ajuda/Documentation/issues/214)

## PRs relacionados, se houver

branch | PR
------ | ------
214-OpenWhatsappForRequests | [214 - Abrir whatsapp para pedidos](https://github.com/mia-ajuda/Frontend/pull/204)

## Tarefas gerais realizadas
* Adicionar método to string no object id retornado pelo mongo.
