### PR TITLE
chore: add missing parameter

### DIFF
--- a/src/services/SocialNetworkService.js
+++ b/src/services/SocialNetworkService.js
@@ -93,7 +93,7 @@ class SocialNetworkService {
     const categoryArray = null;
 
     const helps = await this.helpRepository.getHelpListByStatus(userId, statusList, helper);
-    const offers = await this.offerdHelpRepository.list(userId, categoryArray, getOtherUsers);
+    const offers = await this.offerdHelpRepository.list(userId, false, categoryArray, getOtherUsers);
 
     const activities = { helps, offers };
     return activities;


### PR DESCRIPTION
## Descrição 
O endpoint estava quebrando por falta do parâmetro se era ou não entidade.


## Tarefas gerais realizadas
* Adição do parâmetro isEntity=false que estava faltando na lógica da rede social